### PR TITLE
Solving the double error dialog box bug

### DIFF
--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
@@ -103,65 +103,65 @@ public class OVirtClient {
         return entities;
     }
 
-    public void startVm(final String vmId) {
+    public void startVm(final String vmId, Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.startVm(new Action(), vmId);
                 return null;
             }
-        }, null);
+        }, response);
     }
 
-    public void stopVm(final String vmId) {
+    public void stopVm(final String vmId,Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.stopVm(new Action(), vmId);
                 return null;
             }
-        }, null);
+        }, response);
 
     }
 
-    public void rebootVm(final String vmId) {
+    public void rebootVm(final String vmId, Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.rebootVm(new Action(), vmId);
                 return null;
             }
-        }, null);
+        }, response);
     }
 
-    public void migrateVmToHost(final String vmId, final String hostId) {
+    public void migrateVmToHost(final String vmId, final String hostId, Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.migrateVmToHost(new ActionMigrate(hostId), vmId);
                 return null;
             }
-        }, null);
+        }, response);
     }
 
-    public void migrateVmToDefaultHost(final String vmId) {
+    public void migrateVmToDefaultHost(final String vmId, Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.migrateVmToHost(new Action(), vmId);
                 return null;
             }
-        }, null);
+        }, response);
     }
 
-    public void cancelMigration(final String vmId) {
+    public void cancelMigration(final String vmId, Response response) {
         fireRestRequest(new Request<Void>() {
             @Override
             public Void fire() {
                 restClient.cancelMigration(new Action(), vmId);
                 return null;
             }
-        }, null);
+        }, response);
     }
 
     public void getVm(final String vmId, Response<Vm> response) {

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/vms/VmDetailActivity.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/vms/VmDetailActivity.java
@@ -142,8 +142,14 @@ public class VmDetailActivity extends MovirtActivity
     @OptionsItem(R.id.action_run)
     @Background
     void start() {
-        client.startVm(vmId);
-        syncVm();
+        client.startVm(vmId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @OptionsItem(R.id.action_stop)
@@ -190,20 +196,38 @@ public class VmDetailActivity extends MovirtActivity
 
     @Background
     void doStop() {
-        client.stopVm(vmId);
-        syncVm();
+        client.stopVm(vmId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @Background
     void doReboot() {
-        client.rebootVm(vmId);
-        syncVm();
+        client.rebootVm(vmId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @Background
     void doCancelMigration() {
-        client.cancelMigration(vmId);
-        syncVm();
+        client.cancelMigration(vmId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @OptionsItem(R.id.action_start_migration)
@@ -230,14 +254,26 @@ public class VmDetailActivity extends MovirtActivity
 
     @Background
     public void doMigrationToDefault() {
-        client.migrateVmToDefaultHost(vmId);
-        syncVm();
+        client.migrateVmToDefaultHost(vmId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @Background
     public void doMigrationTo(String hostId) {
-        client.migrateVmToHost(vmId, hostId);
-        syncVm();
+        client.migrateVmToHost(vmId, hostId, new OVirtClient.SimpleResponse() {
+
+            @Override
+            public void onResponse(Object o) throws RemoteException {
+                syncVm();
+            }
+
+        });
     }
 
     @OptionsItem(R.id.action_console)


### PR DESCRIPTION
On bad connection, when we perform any VM activity, two error dialog boxes appear. This bug is solved here by removing the need for syncVm() on bad connection.