### PR TITLE
refactoring: Reduce duplication in sync* logic

### DIFF
--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/BaseEntityFacade.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/BaseEntityFacade.java
@@ -1,0 +1,35 @@
+package org.ovirt.mobile.movirt.facade;
+
+import android.database.Cursor;
+
+import org.androidannotations.annotations.Bean;
+import org.androidannotations.annotations.EBean;
+import org.ovirt.mobile.movirt.model.EntityMapper;
+import org.ovirt.mobile.movirt.model.OVirtEntity;
+import org.ovirt.mobile.movirt.rest.OVirtClient;
+import org.ovirt.mobile.movirt.sync.SyncAdapter;
+
+@EBean
+public abstract class BaseEntityFacade<E extends OVirtEntity> implements EntityFacade<E> {
+
+    @Bean
+    SyncAdapter syncAdapter;
+
+    private final Class<E> clazz;
+
+    protected BaseEntityFacade(Class<E> clazz) {
+        this.clazz = clazz;
+    }
+
+    protected abstract OVirtClient.Request<E> getRestRequest(String id);
+
+    @Override
+    public E mapFromCursor(Cursor cursor) {
+        return EntityMapper.forEntity(clazz).fromCursor(cursor);
+    }
+
+    @Override
+    public void sync(String id, OVirtClient.Response<E> response) {
+        syncAdapter.syncEntity(clazz, getRestRequest(id), response);
+    }
+}

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/HostFacade.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/HostFacade.java
@@ -18,17 +18,16 @@ import java.util.Collection;
 import java.util.List;
 
 @EBean
-public class HostFacade implements EntityFacade<Host> {
-
-    @Bean
-    SyncAdapter syncAdapter;
+public class HostFacade extends BaseEntityFacade<Host> {
 
     @Bean
     HostTriggerResolver hostTriggerResolver;
 
-    @Override
-    public Host mapFromCursor(Cursor cursor) {
-        return EntityMapper.forEntity(Host.class).fromCursor(cursor);
+    @Bean
+    OVirtClient oVirtClient;
+
+    public HostFacade() {
+        super(Host.class);
     }
 
     @Override
@@ -40,11 +39,6 @@ public class HostFacade implements EntityFacade<Host> {
     }
 
     @Override
-    public void sync(String id, OVirtClient.Response<Host> response) {
-        syncAdapter.syncHost(id, response);
-    }
-
-    @Override
     public Collection<Trigger<Host>> getAllTriggers() {
         return hostTriggerResolver.getAllTriggers();
     }
@@ -52,5 +46,10 @@ public class HostFacade implements EntityFacade<Host> {
     @Override
     public List<Trigger<Host>> getTriggers(Host entity, Collection<Trigger<Host>> allTriggers) {
         return hostTriggerResolver.getTriggers(entity, allTriggers);
+    }
+
+    @Override
+    protected OVirtClient.Request<Host> getRestRequest(String id) {
+        return oVirtClient.getHostRequest(id);
     }
 }

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/StorageDomainFacade.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/StorageDomainFacade.java
@@ -16,14 +16,13 @@ import java.util.Collection;
 import java.util.List;
 
 @EBean
-public class StorageDomainFacade implements EntityFacade<StorageDomain> {
+public class StorageDomainFacade extends BaseEntityFacade<StorageDomain> {
 
     @Bean
-    SyncAdapter syncAdapter;
+    OVirtClient oVirtClient;
 
-    @Override
-    public StorageDomain mapFromCursor(Cursor cursor) {
-        return EntityMapper.forEntity(StorageDomain.class).fromCursor(cursor);
+    public StorageDomainFacade() {
+        super(StorageDomain.class);
     }
 
     @Override
@@ -32,11 +31,6 @@ public class StorageDomainFacade implements EntityFacade<StorageDomain> {
         intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setData(entity.getUri());
         return intent;
-    }
-
-    @Override
-    public void sync(String id, OVirtClient.Response<StorageDomain> response) {
-        syncAdapter.syncStorageDomain(id, response);
     }
 
     @Override
@@ -49,5 +43,10 @@ public class StorageDomainFacade implements EntityFacade<StorageDomain> {
     public List<Trigger<StorageDomain>> getTriggers(StorageDomain entity, Collection<Trigger<StorageDomain>> allTriggers) {
         //TODO: StorageDomainTriggerResolver not implemented, so return an empty list
         return new ArrayList<>();
+    }
+
+    @Override
+    protected OVirtClient.Request<StorageDomain> getRestRequest(String id) {
+        return oVirtClient.getStorageDomainRequest(id);
     }
 }

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/VmFacade.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/facade/VmFacade.java
@@ -18,17 +18,16 @@ import java.util.Collection;
 import java.util.List;
 
 @EBean
-public class VmFacade implements EntityFacade<Vm> {
+public class VmFacade extends BaseEntityFacade<Vm> {
 
     @Bean
     VmTriggerResolver triggerResolver;
 
     @Bean
-    SyncAdapter syncAdapter;
+    OVirtClient oVirtClient;
 
-    @Override
-    public Vm mapFromCursor(Cursor cursor) {
-        return EntityMapper.forEntity(Vm.class).fromCursor(cursor);
+    public VmFacade() {
+        super(Vm.class);
     }
 
     @Override
@@ -40,11 +39,6 @@ public class VmFacade implements EntityFacade<Vm> {
     }
 
     @Override
-    public void sync(String id, OVirtClient.Response<Vm> response) {
-        syncAdapter.syncVm(id, response);
-    }
-
-    @Override
     public Collection<Trigger<Vm>> getAllTriggers() {
         return triggerResolver.getAllTriggers();
     }
@@ -52,5 +46,10 @@ public class VmFacade implements EntityFacade<Vm> {
     @Override
     public List<Trigger<Vm>> getTriggers(Vm entity, Collection<Trigger<Vm>> allTriggers) {
         return triggerResolver.getTriggers(entity, allTriggers);
+    }
+
+    @Override
+    protected OVirtClient.Request<Vm> getRestRequest(String id) {
+        return oVirtClient.getVmRequest(id);
     }
 }

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
@@ -9,6 +9,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.RemoteException;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.widget.Toast;
 
@@ -167,13 +168,18 @@ public class OVirtClient {
         }, response);
     }
 
-    public void getVm(final String vmId, Response<Vm> response) {
-        fireRestRequest(new Request<Vm>() {
+    @NonNull
+    public Request<Vm> getVmRequest(final String vmId) {
+        return new Request<Vm>() {
             @Override
             public Vm fire() {
                 return restClient.getVm(vmId).toEntity();
             }
-        }, response);
+        };
+    }
+
+    public void getVm(final String vmId, Response<Vm> response) {
+        fireRestRequest(getVmRequest(vmId), response);
     }
 
     public void activateHost(final String hostId, Response<Void> response) {
@@ -196,22 +202,32 @@ public class OVirtClient {
         }, response);
     }
 
-    public void getHost(final String hostId, Response<Host> response) {
-        fireRestRequest(new Request<Host>() {
+    @NonNull
+    public Request<Host> getHostRequest(final String hostId) {
+        return new Request<Host>() {
             @Override
             public Host fire() {
                 return restClient.getHost(hostId).toEntity();
             }
-        }, response);
+        };
     }
 
-    public void getStorageDomain(final String storageDomainId, Response<StorageDomain> response) {
-        fireRestRequest(new Request<StorageDomain>() {
+    public void getHost(final String hostId, Response<Host> response) {
+        fireRestRequest(getHostRequest(hostId), response);
+    }
+
+    @NonNull
+    public Request<StorageDomain> getStorageDomainRequest(final String storageDomainId) {
+        return new Request<StorageDomain>() {
             @Override
             public StorageDomain fire() {
                 return restClient.getStorageDomain(storageDomainId).toEntity();
             }
-        }, response);
+        };
+    }
+
+    public void getStorageDomain(final String storageDomainId, Response<StorageDomain> response) {
+        fireRestRequest(getStorageDomainRequest(storageDomainId), response);
     }
 
     public void getConsoleTicket(final String vmId, Response<ActionTicket> response) {
@@ -389,7 +405,7 @@ public class OVirtClient {
     /**
      * has to be synced because of error handling - otherwise it would not be possible to bind the error
      */
-    private synchronized <T> void fireRestRequest(final Request<T> request, final Response<T> response) {
+    public synchronized <T> void fireRestRequest(final Request<T> request, final Response<T> response) {
         if (authenticator.enforceBasicAuth()) {
             fireRequestWithHttpBasicAuth(request, response);
         } else {

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/sync/SyncAdapter.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/sync/SyncAdapter.java
@@ -55,10 +55,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
     MovirtAuthenticator authenticator;
     @Bean
     NotificationHelper notificationHelper;
-    /**
-     * access to the {@code batch} field should be always under synchronized(this)
-     */
-    ProviderFacade.BatchBuilder batch;
 
     public SyncAdapter(Context context) {
         super(context, true);
@@ -87,10 +83,16 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             return;
         }
 
-        sendSyncIntent(true);
         try {
-            // split to two methods so at least the quick entities can be already shown / used until the slow ones get processed (better ux)
-            updateAll(tryEvents);
+            updateClusters();
+            updateHosts();
+            updateVms();
+            updateDataCenters();
+            updateStorageDomains();
+
+            if (tryEvents) {
+                eventsHandler.updateEvents(false);
+            }
         } catch (Exception e) {
             Log.e(TAG, "Error updating data", e);
             Intent intent = new Intent(Broadcasts.CONNECTION_FAILURE);
@@ -99,74 +101,80 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
         }
     }
 
-    public synchronized <E extends OVirtEntity> void syncEntity(final Class<E> clazz,
+    public <E extends OVirtEntity> void syncEntity(final Class<E> clazz,
                                                                 OVirtClient.Request<E> request,
                                                                 OVirtClient.Response<E> response) {
         final EntityFacade<E> entityFacade = entityFacadeLocator.getFacade(clazz);
-        initBatch();
-        oVirtClient.fireRestRequest(request, new OVirtClient.CompositeResponse<>(new OVirtClient.SimpleResponse<E>() {
+        final ProviderFacade.BatchBuilder batch = provider.batch();
+        oVirtClient.fireRestRequest(request, new OVirtClient.CompositeResponse<>(new SyncResponse<E>() {
             @Override
             public void onResponse(E entity) throws RemoteException {
                 Collection<Trigger<E>> allTriggers = entityFacade.getAllTriggers();
-                updateLocalEntity(entity, clazz, allTriggers);
-                applyBatch();
+                updateLocalEntity(entity, clazz, allTriggers, batch);
+                applyBatch(batch);
             }
         }, response));
     }
 
-    private void updateAll(final boolean tryEvents) throws RemoteException {
-        initBatch();
-        // TODO: we really need promises here
-        // TODO: ideally split each request and save vms, hosts, ... in separate batches
-        oVirtClient.getVms(new OVirtClient.SimpleResponse<List<Vm>>() {
+    /** Sends broadcasts about start/stop of sync around response */
+    private class SyncResponse<T> extends OVirtClient.SimpleResponse<T> {
+        @Override
+        public void before() {
+            sendSyncIntent(true);
+        }
+
+        @Override
+        public void after() {
+            sendSyncIntent(false);
+        }
+    }
+
+    private void updateClusters() {
+        oVirtClient.getClusters(new SyncResponse<List<Cluster>>() {
             @Override
-            public void onResponse(final List<Vm> remoteVms) throws RemoteException {
-                oVirtClient.getClusters(new OVirtClient.SimpleResponse<List<Cluster>>() {
-                    @Override
-                    public void onResponse(final List<Cluster> remoteClusters) throws RemoteException {
-                        oVirtClient.getHosts(new OVirtClient.SimpleResponse<List<Host>>() {
-                            @Override
-                            public void onResponse(final List<Host> remoteHosts) throws RemoteException {
-                                oVirtClient.getDataCenters(new OVirtClient.SimpleResponse<List<DataCenter>>() {
-                                    @Override
-                                    public void onResponse(final List<DataCenter> remoteDataCenters) throws RemoteException {
-                                        oVirtClient.getStorageDomains(new OVirtClient.SimpleResponse<List<StorageDomain>>(){
-                                            @Override
-                                            public void onResponse(final List<StorageDomain> remoteStorageDomains) throws RemoteException {
-                                                updateLocalEntities(remoteClusters, Cluster.class);
-                                                updateLocalEntities(remoteHosts, Host.class);
-                                                updateLocalEntities(remoteVms, Vm.class);
-                                                updateLocalEntities(remoteDataCenters, DataCenter.class);
-                                                updateLocalEntities(remoteStorageDomains, StorageDomain.class);
-
-                                                applyBatch();
-
-												if (tryEvents) {
-		                                            eventsHandler.updateEvents(false);
-		                                        }
-											}
-                                        });
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-            }
-
-            @Override
-            public void after() {
-                sendSyncIntent(false);
+            public void onResponse(List<Cluster> clusters) throws RemoteException {
+                updateLocalEntities(clusters, Cluster.class);
             }
         });
-
     }
 
-    private void initBatch() {
-        batch = provider.batch();
+    private void updateVms() {
+        oVirtClient.getVms(new SyncResponse<List<Vm>>() {
+            @Override
+            public void onResponse(List<Vm> vms) throws RemoteException {
+                updateLocalEntities(vms, Vm.class);
+            }
+        });
     }
 
-    private void applyBatch() {
+    private void updateHosts() {
+        oVirtClient.getHosts(new SyncResponse<List<Host>>() {
+            @Override
+            public void onResponse(List<Host> hosts) throws RemoteException {
+                updateLocalEntities(hosts, Host.class);
+            }
+        });
+    }
+
+    private void updateDataCenters() {
+        oVirtClient.getDataCenters(new SyncResponse<List<DataCenter>>() {
+            @Override
+            public void onResponse(List<DataCenter> dataCenters) throws RemoteException {
+                updateLocalEntities(dataCenters, DataCenter.class);
+            }
+        });
+    }
+
+    private void updateStorageDomains() {
+        oVirtClient.getStorageDomains(new SyncResponse<List<StorageDomain>>() {
+            @Override
+            public void onResponse(List<StorageDomain> storageDomains) throws RemoteException {
+                updateLocalEntities(storageDomains, StorageDomain.class);
+            }
+        });
+    }
+
+    private void applyBatch(ProviderFacade.BatchBuilder batch) {
         if (batch.isEmpty()) {
             Log.i(TAG, "No updates necessary");
         } else {
@@ -190,6 +198,8 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             return;
         }
 
+        ProviderFacade.BatchBuilder batch = provider.batch();
+
         while (cursor.moveToNext()) {
             E localEntity = mapper.fromCursor(cursor);
             E remoteEntity = entityMap.get(localEntity.getId());
@@ -198,7 +208,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
                 batch.delete(localEntity);
             } else { // existing entity, update stats if changed
                 entityMap.remove(localEntity.getId());
-                checkEntityChanged(localEntity, remoteEntity, entityFacade, allTriggers);
+                checkEntityChanged(localEntity, remoteEntity, entityFacade, allTriggers, batch);
             }
         }
 
@@ -208,9 +218,11 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             Log.i(TAG, "Scheduling insert for entity: id = " + entity.getId());
             batch.insert(entity);
         }
+
+        applyBatch(batch);
     }
 
-    private <E extends OVirtEntity> void updateLocalEntity(E remoteEntity, Class<E> clazz, Collection<Trigger<E>> allTriggers) {
+    private <E extends OVirtEntity> void updateLocalEntity(E remoteEntity, Class<E> clazz, Collection<Trigger<E>> allTriggers, ProviderFacade.BatchBuilder batch) {
         final EntityFacade<E> triggerResolver = entityFacadeLocator.getFacade(clazz);
 
         Collection<E> localEntities = provider.query(clazz).id(remoteEntity.getId()).all();
@@ -219,11 +231,12 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
             batch.insert(remoteEntity);
         } else {
             E localEntity = localEntities.iterator().next();
-            checkEntityChanged(localEntity, remoteEntity, triggerResolver, allTriggers);
+            checkEntityChanged(localEntity, remoteEntity, triggerResolver, allTriggers, batch);
         }
     }
 
-    private <E extends OVirtEntity> void checkEntityChanged(E localEntity, E remoteEntity, EntityFacade<E> entityFacade, Collection<Trigger<E>> allTriggers) {
+    private <E extends OVirtEntity> void checkEntityChanged(E localEntity, E remoteEntity, EntityFacade<E> entityFacade,
+                                                            Collection<Trigger<E>> allTriggers, ProviderFacade.BatchBuilder batch) {
         if (!localEntity.equals(remoteEntity)) {
             if (entityFacade != null) {
                 final List<Trigger<E>> triggers = entityFacade.getTriggers(localEntity, allTriggers);

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/sync/SyncAdapter.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/sync/SyncAdapter.java
@@ -99,40 +99,16 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter {
         }
     }
 
-    public synchronized void syncVm(final String id, final OVirtClient.Response<Vm> response) {
+    public synchronized <E extends OVirtEntity> void syncEntity(final Class<E> clazz,
+                                                                OVirtClient.Request<E> request,
+                                                                OVirtClient.Response<E> response) {
+        final EntityFacade<E> entityFacade = entityFacadeLocator.getFacade(clazz);
         initBatch();
-        oVirtClient.getVm(id, new OVirtClient.CompositeResponse<>(new OVirtClient.SimpleResponse<Vm>() {
+        oVirtClient.fireRestRequest(request, new OVirtClient.CompositeResponse<>(new OVirtClient.SimpleResponse<E>() {
             @Override
-            public void onResponse(Vm vm) throws RemoteException {
-                final EntityFacade<Vm> entityFacade = entityFacadeLocator.getFacade(Vm.class);
-                Collection<Trigger<Vm>> allTriggers = entityFacade.getAllTriggers();
-                updateLocalEntity(vm, Vm.class, allTriggers);
-                applyBatch();
-            }
-        }, response));
-    }
-
-    public synchronized void syncHost(String id, OVirtClient.Response<Host> response) {
-        initBatch();
-        oVirtClient.getHost(id, new OVirtClient.CompositeResponse<>(new OVirtClient.SimpleResponse<Host>() {
-            @Override
-            public void onResponse(Host host) throws RemoteException {
-                final EntityFacade<Host> entityFacade = entityFacadeLocator.getFacade(Host.class);
-                Collection<Trigger<Host>> allTriggers = entityFacade.getAllTriggers();
-                updateLocalEntity(host, Host.class, allTriggers);
-                applyBatch();
-            }
-        }, response));
-    }
-
-    public synchronized void syncStorageDomain(String id, OVirtClient.Response<StorageDomain> response) {
-        initBatch();
-        oVirtClient.getStorageDomain(id, new OVirtClient.CompositeResponse<>(new OVirtClient.SimpleResponse<StorageDomain>() {
-            @Override
-            public void onResponse(StorageDomain storageDomain) throws RemoteException {
-                final EntityFacade<StorageDomain> entityFacade = entityFacadeLocator.getFacade(StorageDomain.class);
-                Collection<Trigger<StorageDomain>> allTriggers = entityFacade.getAllTriggers();
-                updateLocalEntity(storageDomain, StorageDomain.class, allTriggers);
+            public void onResponse(E entity) throws RemoteException {
+                Collection<Trigger<E>> allTriggers = entityFacade.getAllTriggers();
+                updateLocalEntity(entity, clazz, allTriggers);
                 applyBatch();
             }
         }, response));


### PR DESCRIPTION
Moved the responsibility of choosing particular oVirtClient rest method (based
on entity type) to EntityFacade and implemented generic syncEntity method in
SyncAdapter that utilizes this new EntityFacade feature.