### PR TITLE
Explicitly add "Version" header to all API calls

### DIFF
--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/rest/OVirtClient.java
@@ -64,6 +64,7 @@ public class OVirtClient {
     public static final String JSESSIONID = "JSESSIONID";
     public static final String FILTER = "Filter";
     public static final String PREFER = "Prefer";
+    public static final String VERSION = "Version";
     private static final String TAG = OVirtClient.class.getSimpleName();
     ObjectMapper mapper = new ObjectMapper();
 
@@ -530,6 +531,7 @@ public class OVirtClient {
         restClient.setCookie("JSESSIONID", "");
         requestFactory.setCertificateHandlingMode(authenticator.getCertHandlingStrategy());
         restClient.setHeader(FILTER, Boolean.toString(!hasAdminPrivileges));
+        restClient.setHeader(VERSION, "3");
         restClient.login();
         String sessionId = restClient.getCookie("JSESSIONID");
         restClient.setHttpBasicAuth("", "");


### PR DESCRIPTION
Version 4 of oVirt engine will support versions 3 and 4 of the API.
Version 3 will be identical to the one provided by version 3.6 of the
engine, but version 4 will be different and not backwards compatible.
Users of the API can select what version to use with the "Version" HTTP
header or with the "/v3" or "/v4" URL suffixes. If the version isn't
selected explicitly then the server will automatically select a version,
by default version 4. This patch changes moVirt to explicitly request
version 3 of the API, using the "Version" header.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matobet/movirt/187)
<!-- Reviewable:end -->
